### PR TITLE
chore: bump version to 1.8.1 and update npm deps hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,33 +8,35 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  outputs = inputs @ {
+    self,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
-      perSystem = { pkgs, ... }:
-        let
-          nodejs = pkgs.nodejs_18;
+      perSystem = {pkgs, ...}: let
+        nodejs = pkgs.nodejs_18;
 
-          mcp-hub = pkgs.buildNpmPackage {
-            pname = "mcp-hub";
-            version = "1.7.3";
-            src = self;
-            inherit nodejs;
+        mcp-hub = pkgs.buildNpmPackage {
+          pname = "mcp-hub";
+          version = "1.7.3";
+          src = self;
+          inherit nodejs;
 
-            nativeBuildInputs = [ nodejs ];
-            npmDepsHash = "sha256-zmOGESo28HSUk3vSOEplpWIyn9m3U/W6qPeZaJjx1iE=";
-          };
-        in
-        {
-          packages = {
-            default = mcp-hub;
-            mcp-hub = mcp-hub;
-          };
-
-          devShells.default = pkgs.mkShell {
-            buildInputs = [ nodejs ];
-          };
+          nativeBuildInputs = [nodejs];
+          npmDepsHash = "sha256-zmOGESo28HSUk3vSOEplpWIyn9m3U/W6qPeZaJjx1iE=";
         };
+      in {
+        packages = {
+          default = mcp-hub;
+          mcp-hub = mcp-hub;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [nodejs];
+        };
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,12 @@
 
         mcp-hub = pkgs.buildNpmPackage {
           pname = "mcp-hub";
-          version = "1.7.3";
+          version = "1.8.1";
           src = self;
           inherit nodejs;
 
           nativeBuildInputs = [nodejs];
-          npmDepsHash = "sha256-zmOGESo28HSUk3vSOEplpWIyn9m3U/W6qPeZaJjx1iE=";
+          npmDepsHash = "sha256-A4d9l8YpRaJdNfa934IEG0a2SLRmwW+CfTWgoXx3vwA=";
         };
       in {
         packages = {


### PR DESCRIPTION
Update package version from 1.7.3 to 1.8.1 and update corresponding npm dependencies hash to reflect new dependency state