### PR TITLE
chore: bump version to 2.2.0 in flake.nix with new hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,12 @@
 
         mcp-hub = pkgs.buildNpmPackage {
           pname = "mcp-hub";
-          version = "2.1.1";
+          version = "2.2.0";
           src = self;
           inherit nodejs;
 
           nativeBuildInputs = [nodejs];
-          npmDepsHash = "sha256-2cd8y3SNrbKEQ5ZWWt0Y74ecn7TQfAF9bASYUBMIlDM=";
+          npmDepsHash = "sha256-nFd1G8Vlo+VfAV4gACqczz5HVsGD8rhtYXlCXS9ahoA=";
         };
       in {
         packages = {


### PR DESCRIPTION
I am using NixOS and neovim, and depends on the version consistency between mcp-hub.nvim and mcp-hub. 

This pr just upgrade the flake version to match the mcp-hub version.