### PR TITLE
fix: Use expected constant for tool list changed

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -117,7 +117,7 @@ class ServiceManager {
 
     // Server-specific events
     this.mcpHub.on("toolsChanged", (data) => {
-      this.broadcastSubscriptionEvent(SubscriptionTypes.TOOLS_CHANGED, data)
+      this.broadcastSubscriptionEvent(SubscriptionTypes.TOOL_LIST_CHANGED, data)
     });
 
     this.mcpHub.on("resourcesChanged", (data) => {


### PR DESCRIPTION
# Summary
I think the toolsChanged event is broadcasting with a non-existent constant. I think the correct constant is TOOL_LIST_CHANGED:
https://github.com/ravitemer/mcp-hub/blob/main/src/utils/sse-manager.js#L30

# Context
I was building a server that updates the tools list dynamically depending on other tools calls. Basically if you call the "ping" action, the list would update to only include the "pong" action. Back and forth. I noticed that the UI in mcphub.nvim wasn't updating when this notification was sent and tracked it down to this. This change seems to update the result in an updated UI as expected.

If you can point me to where you'd like to add tests or if you think they're necessary, I'm happy to add them.

Thanks!