### PR TITLE
feat: implement XDG Base Directory Specification for file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,10 @@ MCP Hub emits several types of events:
 
 ## Logging
 
-MCP Hub uses structured JSON logging for all events. Logs are written to both console and file at `~/.mcp-hub/logs/mcp-hub.log`:
+MCP Hub uses structured JSON logging for all events. Logs are written to both console and file following XDG Base Directory Specification:
+
+- **XDG compliant**: `$XDG_STATE_HOME/mcp-hub/logs/mcp-hub.log` (typically `~/.local/state/mcp-hub/logs/mcp-hub.log`)
+- **Legacy fallback**: `~/.mcp-hub/logs/mcp-hub.log` (for backward compatibility)
 
 ```json
 {

--- a/src/marketplace.js
+++ b/src/marketplace.js
@@ -1,10 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
-import os from "os";
 import { promisify } from "util";
 import { exec as execCb } from "child_process";
 import logger from "./utils/logger.js";
 import { MCPHubError } from "./utils/errors.js";
+import { getCacheDirectory } from "./utils/xdg-paths.js";
 
 const exec = promisify(execCb);
 
@@ -77,7 +77,7 @@ async function fetchWithFallback(url, options = {}) {
 
 //TODO: implement sort of custom database for reliability instead of using cline mcp-marketplace
 const API_BASE_URL = "https://api.cline.bot/v1/mcp";
-const CACHE_DIR = path.join(os.homedir(), ".mcp-hub", "cache");
+const CACHE_DIR = getCacheDirectory();
 const CACHE_FILE = "marketplace.json";
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 1 day in milliseconds
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,12 +1,12 @@
 import fs from "fs";
 import path from "path";
-import os from "os";
+import { getLogDirectory } from "./xdg-paths.js";
 
 /**
  * Logger class that handles both file and console logging with structured JSON output
  */
 
-const LOG_DIR = path.join(os.homedir(), ".mcp-hub", "logs");
+const LOG_DIR = getLogDirectory();
 const LOG_FILE = "mcp-hub.log";
 class Logger {
   constructor(options = {}) {

--- a/src/utils/oauth-provider.js
+++ b/src/utils/oauth-provider.js
@@ -5,14 +5,14 @@
 import logger from "./logger.js";
 import fs from 'fs/promises';
 import path from 'path';
-import os from 'os';
+import { getDataDirectory } from "./xdg-paths.js";
 
 // File level storage
 let serversStorage = {};
 
 class StorageManager {
   constructor() {
-    this.path = path.join(os.homedir(), '.mcp-hub', 'oauth-storage.json');
+    this.path = path.join(getDataDirectory(), 'oauth-storage.json');
   }
 
   async init() {

--- a/src/utils/xdg-paths.js
+++ b/src/utils/xdg-paths.js
@@ -1,0 +1,68 @@
+/**
+ * XDG Base Directory Specification utilities with backward compatibility
+ *
+ * This module provides XDG-compliant directory paths while maintaining
+ * backward compatibility with existing ~/.mcp-hub installations.
+ */
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Get XDG-compliant directory paths with fallback to legacy ~/.mcp-hub
+ *
+ * @param {string} type - Directory type: 'data', 'state', or 'config'
+ * @param {string} subdir - Subdirectory within the base directory
+ * @returns {string} The resolved directory path
+ */
+export function getXDGDirectory(type, subdir = '') {
+  const homeDir = os.homedir();
+  const legacyPath = path.join(homeDir, '.mcp-hub', subdir);
+
+  // Check if legacy path exists and use it for backward compatibility
+  if (fs.existsSync(legacyPath)) {
+    return legacyPath;
+  }
+
+  let basePath;
+
+  switch (type) {
+    case 'data':
+      basePath = process.env.XDG_DATA_HOME || path.join(homeDir, '.local', 'share');
+      break;
+    case 'state':
+      basePath = process.env.XDG_STATE_HOME || path.join(homeDir, '.local', 'state');
+      break;
+    case 'config':
+      basePath = process.env.XDG_CONFIG_HOME || path.join(homeDir, '.config');
+      break;
+    default:
+      throw new Error(`Unknown XDG directory type: ${type}`);
+  }
+
+  return path.join(basePath, 'mcp-hub', subdir);
+}
+
+/**
+ * Get the log directory path (XDG_STATE_HOME or ~/.local/state/mcp-hub/logs)
+ * Falls back to ~/.mcp-hub/logs if it exists
+ */
+export function getLogDirectory() {
+  return getXDGDirectory('state', 'logs');
+}
+
+/**
+ * Get the cache directory path (XDG_DATA_HOME or ~/.local/share/mcp-hub/cache)
+ * Falls back to ~/.mcp-hub/cache if it exists
+ */
+export function getCacheDirectory() {
+  return getXDGDirectory('data', 'cache');
+}
+
+/**
+ * Get the data directory path (XDG_DATA_HOME or ~/.local/share/mcp-hub)
+ * Falls back to ~/.mcp-hub if it exists
+ */
+export function getDataDirectory() {
+  return getXDGDirectory('data');
+}


### PR DESCRIPTION
Migrate from hardcoded ~/.mcp-hub paths to XDG-compliant directories while maintaining backward compatibility for existing installations.

- Add new XDG paths utility module with fallback logic
- Update marketplace cache to use XDG data directory
- Update logger to use XDG state directory for logs
- Update OAuth storage to use XDG data directory
- Update documentation to reflect new path structure

The implementation checks for existing ~/.mcp-hub directories and uses them for backward compatibility, otherwise defaults to XDG-compliant paths like ~/.local/state/mcp-hub/logs and ~/.local/share/mcp-hub/cache.